### PR TITLE
Set overflow feature in table

### DIFF
--- a/css/summary.css
+++ b/css/summary.css
@@ -8,8 +8,10 @@ h3 {
 
 #links_table {
 	display: block;
-    overflow-x: auto; 
+    	overflow-x: auto; 
 	max-width: fit-content;
+	overflow-y: auto;
+	max-height: 750px;
 }
 
 table a {


### PR DESCRIPTION
For large datasets height of tables needs to be adjusted because it becomes cumbersome for user to scroll up and down the whole webpage.